### PR TITLE
feat: Don't Keep Birthdates

### DIFF
--- a/packages/backend/services/ValidationService.js
+++ b/packages/backend/services/ValidationService.js
@@ -311,10 +311,8 @@ module.exports = class ValidationService {
                     }
                 }
             } else if ( type === 'admin-edit' ) {
-                // With password authentication, they are allowed to change any
-                // of the editable fields and not required to change any of
-                // them.  `username` is not editable and can only be set at
-                // user creation.
+                // Admins are allowed to edit status in order to, for instance,
+                // ban a user.
                 const disallowedFields = [ 'username' ]
 
                 for(const disallowedField of disallowedFields ) {
@@ -499,6 +497,11 @@ module.exports = class ValidationService {
                     })
                 }
             }
+        }
+
+        if ( this.has(user, 'birthdate') ) {
+            const birthdateErrors = validation.User.validateBirthdate(user.birthdate, existing?.birthdate, existing ? 'update' : 'create')
+            errors.push(...birthdateErrors)
         }
 
         if ( this.has(user, 'about') ) {

--- a/packages/shared/validation/entities/User.js
+++ b/packages/shared/validation/entities/User.js
@@ -66,7 +66,7 @@ const validateBirthdate = function(value, existing, action) {
     const validator = new DateValidator('birthdate', value, existing, action)
     const errors = validator
         .isRequiredToCreate()
-        .mustNotBeNull()
+        .mustNotBeNullOnCreate()
         .mustBeString()
         .mustNotBeEmpty()
         .mustBeValidDate()

--- a/packages/shared/validation/types/BaseValidator.js
+++ b/packages/shared/validation/types/BaseValidator.js
@@ -77,5 +77,17 @@ module.exports = class BaseValidator {
         }
         return this
     }
+
+    mustNotBeNullOnCreate() {
+        if ( this.action === BaseValidator.ACTIONS.CREATE && this.value === null ) {
+            this.errors.push({
+                type: `${this.name}:null`,
+                log: `${this.name} may not be null.`,
+                message: `${this.name} may not be null.`
+            })
+        }
+
+        return this
+    }
 }
 

--- a/web-application/client/lib/hooks/useAuthentication.js
+++ b/web-application/client/lib/hooks/useAuthentication.js
@@ -1,24 +1,48 @@
+/******************************************************************************
+ *
+ *  Communities -- Non-profit, cooperative social media 
+ *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
 import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 
+import { useRequest } from '/lib/hooks/useRequest'
+
+import { patchUser } from '/state/User'
+
 export function useAuthentication() {
     const currentUser = useSelector((state) => state.authentication.currentUser)
+
+    const [request, makeRequest] = useRequest()
 
     const navigate = useNavigate()
     useEffect(function() {
         if ( currentUser ) {
-            if ( currentUser.birthdate === '' ) {
-                // TECHDEBT If we didn't collect their birthdate at
-                // registration then we're just not going to worry about it
-                // for now. Only about 120 people in the database won't
-                // have a birthdate set. The chance that anyone in that
-                // group is underage is pretty damned low. Especially since
-                // it is overwhelmingly pulled from my community.
-                //
-                // We can come back to this in the future if we need to.
 
-            } else {
+            // We don't actually want to keep their birthdate once we've
+            // validated that they pass the Age Gate. We only want to keep it
+            // for people who are underage so that we can continue to age gate
+            // them.
+            //
+            // If the birthdate is an empty string, that means its a user we
+            // never collected the birthdate from.  If it's null, it's a user
+            // who's age has already been validated.
+            if ( currentUser.birthdate !== '' && currentUser.birthdate !== null ) {
                 const birthdate = new Date(currentUser.birthdate)
 
                 const now = new Date() 
@@ -35,6 +59,15 @@ export function useAuthentication() {
                     // Age gate them.
                     navigate('/age-gate')
                     return 
+                } else {
+                    // If they've passed the age gate, then delete their
+                    // birthdate.
+
+                    const userPatch = {
+                        id: currentUser.id,
+                        birthdate: null 
+                    }
+                    makeRequest(patchUser(userPatch))
                 }
             }
 


### PR DESCRIPTION
We don't actually want to hang on to Birthdates right now.  It's sensitive information that we never wanted to collect, we just had to for the age gate.  But once we've validated someone's age, we don't need the birthdate anymore.  So delete it from the database as soon as they are validated.

Resolves #331