### PR TITLE
fix(meta): 'Communties' -> 'Communities' in og/twitter site title

### DIFF
--- a/web-application/client/components/authentication/AcceptInvitationForm.js
+++ b/web-application/client/components/authentication/AcceptInvitationForm.js
@@ -291,7 +291,7 @@ const AcceptInvitationForm = function(props) {
                 <p>Invalid token. {tokenError}</p>
                 <p>If you did get here following a valid invitation, please
                         reach out to us at <a
-                            href="mailto:contact@communities.social">contact@communties.social</a>,
+                            href="mailto:contact@communities.social">contact@communities.social</a>,
                         so we can figure out what went wrong and get you a new
                     invitation.</p>
                 </div>)

--- a/web-application/server/views/index.html
+++ b/web-application/server/views/index.html
@@ -12,7 +12,7 @@
     <meta name="keywords" content="social media, non-profit, cooperative, social media platform, multi-stakeholder cooperative, democratic platform, cooperative platform, cooperative social media, non-profit social media" />
 
     <!-- Open graph meta tags -->
-    <meta property="og:title" content="Communties -- Cooperative Social Media" />
+    <meta property="og:title" content="Communities -- Cooperative Social Media" />
     <meta property="og:type" content="website" />
     <meta property="og:description" content="A social media platform that will be a non-profit, cooperative. Funded by users. Govered by those who build it and use it, together." />
     <meta property="og:image" content="<%- require('../../client/pages/authentication/splash-banner.png') %>" />
@@ -20,7 +20,7 @@
 
     <!-- Twitter open graph meta tags -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Communties -- Cooperative Social Media" />
+    <meta name="twitter:title" content="Communities -- Cooperative Social Media" />
     <meta name="twitter:description" content="A social media platform that will be a non-profit, cooperative. Funded by users. Govered by those who build it and use it, together." />
     <meta name="twitter:image" content="https://communities.social/favicon-32x32.png" />
 


### PR DESCRIPTION
## Summary

\`web-application/server/views/index.html\` had \`og:title\` and \`twitter:title\` both set to \`\"Communties -- Cooperative Social Media\"\`. That string is what shows up on social shares, per #475.

Also fixed an adjacent \`communties.social\` typo in the visible display text of \`AcceptInvitationForm.js\` (the \`mailto:\` href itself was already \`contact@communities.social\`; only the display text was misspelled).

Closes #475

## Testing

Text-only. No other Communties/communties occurrences remain in web-application.