### PR TITLE
fix: add capacitor packages to web-application

### DIFF
--- a/web-application/package-lock.json
+++ b/web-application/package-lock.json
@@ -10,10 +10,12 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@capacitor/app": "7.1.0",
+        "@capacitor/clipboard": "7.0.4",
         "@capacitor/core": "7.4.3",
         "@capacitor/device": "7.0.2",
         "@capacitor/push-notifications": "7.0.3",
         "@capacitor/status-bar": "7.0.3",
+        "@capawesome/capacitor-badge": "7.0.1",
         "@capgo/capacitor-updater": "7.0.36",
         "@communities/backend": "^0.12.5",
         "@communities/session": "^0.12.5",
@@ -3682,6 +3684,15 @@
         "@capacitor/core": ">=7.0.0"
       }
     },
+    "node_modules/@capacitor/clipboard": {
+      "version": "7.0.4",
+      "resolved": "https://communities-843012963492.d.codeartifact.us-east-1.amazonaws.com/npm/communities-shared-npm-repository/@capacitor/clipboard/-/clipboard-7.0.4.tgz",
+      "integrity": "sha512-+kiTRFjwD5UiWRg/m1JA/0Z0DDdsZLa25MLqI1e3MUi3yNZIwVZV5Oj6v4O0gxmpoBxf5A1L1v3weq+vWOBUuQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
     "node_modules/@capacitor/core": {
       "version": "7.4.3",
       "resolved": "https://communities-843012963492.d.codeartifact.us-east-1.amazonaws.com/npm/communities-shared-npm-repository/@capacitor/core/-/core-7.4.3.tgz",
@@ -3713,6 +3724,25 @@
       "version": "7.0.3",
       "resolved": "https://communities-843012963492.d.codeartifact.us-east-1.amazonaws.com/npm/communities-shared-npm-repository/@capacitor/status-bar/-/status-bar-7.0.3.tgz",
       "integrity": "sha512-JyRpVnKwHij9hgPWolF6PK+HT3e2HSPjN11/h2OmKxq8GAdPGARFLv+97eZl0pvuvm0Kka/LpiLb5whXISBg7Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capawesome/capacitor-badge": {
+      "version": "7.0.1",
+      "resolved": "https://communities-843012963492.d.codeartifact.us-east-1.amazonaws.com/npm/communities-shared-npm-repository/@capawesome/capacitor-badge/-/capacitor-badge-7.0.1.tgz",
+      "integrity": "sha512-jhVieRRVLgGO1NU7PW8uWZmf3WD4IsYUlkrJ82KuoRgLFx1tbJGwHU1ro0sUJmEwfLO9vldhBnJJ/J5nHrjbQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/capawesome-team/"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/capawesome"
+        }
+      ],
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"

--- a/web-application/package.json
+++ b/web-application/package.json
@@ -32,10 +32,12 @@
   },
   "dependencies": {
     "@capacitor/app": "7.1.0",
+    "@capacitor/clipboard": "7.0.4",
     "@capacitor/core": "7.4.3",
     "@capacitor/device": "7.0.2",
     "@capacitor/push-notifications": "7.0.3",
     "@capacitor/status-bar": "7.0.3",
+    "@capawesome/capacitor-badge": "7.0.1",
     "@capgo/capacitor-updater": "7.0.36",
     "@communities/backend": "^0.12.5",
     "@communities/session": "^0.12.5",


### PR DESCRIPTION
We install capacitor dependencies at the top level when developing, but we need to install them in the web-application too for deployment.  It's easy to forget during development because the web-application will use the modules from the top-level.