### PR TITLE
fix: mutual friends query is slow making friends list slow

### DIFF
--- a/database/initialization-scripts/schema.sql
+++ b/database/initialization-scripts/schema.sql
@@ -118,7 +118,7 @@ CREATE TABLE mutual_relationships (
 );
 CREATE INDEX mutual_relationships__current_id ON mutual_relationships (current_id);
 CREATE INDEX mutual_relationships__target_id ON mutual_relationships (target_id);
-CREATE INDEX mutual_relationships__mutual_id ON mutual_relationships (mutual_id):
+CREATE INDEX mutual_relationships__mutual_id ON mutual_relationships (mutual_id);
 
 /******************************************************************************
  * Notifications 

--- a/database/initialization-scripts/schema.sql
+++ b/database/initialization-scripts/schema.sql
@@ -110,6 +110,16 @@ CREATE TABLE user_relationships (
 CREATE INDEX user_relationships__user_id ON user_relationships (user_id);
 CREATE INDEX user_relationships__friend_id ON user_relationships (friend_id);
 
+CREATE TABLE mutual_relationships (
+    current_id uuid REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+    target_id uuid REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+    mutual_id uuid REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+    PRIMARY KEY (current_id, target_id, mutual_id)
+);
+CREATE INDEX mutual_relationships__current_id ON mutual_relationships (current_id);
+CREATE INDEX mutual_relationships__target_id ON mutual_relationships (target_id);
+CREATE INDEX mutual_relationships__mutual_id ON mutual_relationships (mutual_id):
+
 /******************************************************************************
  * Notifications 
  *****************************************************************************/

--- a/packages/backend/core.js
+++ b/packages/backend/core.js
@@ -134,6 +134,8 @@ module.exports = class Core {
         this.queues['process-video'] = new BullQueue('process-video', { redis: this.config.redis })
         this.queues['resize-image'] = new BullQueue('resize-image', { redis: this.config.redis })
         this.queues['send-notifications'] = new BullQueue('send-notifications', { redis: this.config.redis })
+        this.queues['add-mutuals-for-relationship'] = new BullQueue('add-mutuals-for-relationship', { redis: this.config.redis })
+        this.queues['remove-mutuals-for-relationship'] = new BullQueue('remove-mutuals-for-relationship', { redis: this.config.redis })
 
         this.postmarkClient = new Postmark.ServerClient(this.config.postmark.api_token)
     }

--- a/packages/backend/daos/UserRelationshipDAO.js
+++ b/packages/backend/daos/UserRelationshipDAO.js
@@ -166,12 +166,12 @@ module.exports = class UserRelationshipDAO extends DAO {
     }
 
     async selectUserRelationships(query) {
-        const params = query.params ? [ ...query.params ] : []
-        const where = query.where ? `WHERE ${query.where}` : ''
-        const order = query.order ? `ORDER BY ${query.order}` : ''
+        const params = query?.params ? [ ...query.params ] : []
+        const where = query?.where ? `WHERE ${query.where}` : ''
+        const order = query?.order ? `ORDER BY ${query.order}` : ''
 
         let paging = ''
-        if ( query.page ) {
+        if ( query?.page ) {
             const page = query.page ? query.page : 1
             const pageSize = query.pageSize ? query.pageSize : DEFAULT_PAGE_SIZE
 

--- a/packages/backend/migrations/Fix495SlowFriendsListMigration.js
+++ b/packages/backend/migrations/Fix495SlowFriendsListMigration.js
@@ -1,0 +1,71 @@
+/******************************************************************************
+ *
+ *  Communities -- Non-profit, cooperative social media 
+ *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+const BaseMigration = require('./BaseMigration')
+
+const UserRelationshipDAO = require('../daos/UserRelationshipDAO')
+const MutualsService = require('../services/MutualsService')
+
+module.exports = class Fix495SlowFriendsListMigration extends BaseMigration {
+
+    constructor(core) {
+        super(core)
+
+        this.userRelationshipDAO = new UserRelationshipDAO(core)
+
+        this.mutualsService = new MutualsService(core)
+    }
+
+    async initForward() { 
+        await this.core.database.query(`
+CREATE TABLE IF NOT EXISTS mutual_relationships (
+    current_id uuid REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+    target_id uuid REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+    mutual_id uuid REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+    PRIMARY KEY (current_id, target_id, mutual_id)
+)
+        `, [])
+
+        await this.core.database.query(`CREATE INDEX IF NOT EXISTS mutual_relationships__current_id ON mutual_relationships (current_id)`, [])
+        await this.core.database.query(`CREATE INDEX IF NOT EXISTS mutual_relationships__target_id ON mutual_relationships (target_id)`, [])
+        await this.core.database.query(`CREATE INDEX IF NOT EXISTS mutual_relationships__mutual_id ON mutual_relationships (mutual_id)`, [])
+    }
+
+    async initBack() { 
+        await this.core.database.query(`DROP INDEX IF EXISTS mutual_relationships__current_id`, [])
+        await this.core.database.query(`DROP INDEX IF EXISTS mutual_relationships__target_id`, [])
+        await this.core.database.query(`DROP INDEX IF EXISTS mutual_relationships__mutual_id`, [])
+
+        await this.core.database.query(`DROP TABLE IF EXISTS mutual_relationships`, [])
+    }
+
+    async migrateForward(targets) { 
+        const relationshipResults = await this.userRelationshipDAO.selectUserRelationships({ 
+            where: `user_relationships.status = $1`,
+            params: ['confirmed']
+        })
+        for(const [id, relationship] of Object.entries(relationshipResults.dictionary)) {
+            await this.mutualsService.addMutualsForRelationship(relationship)
+        }
+    }
+
+    async migrateBack(targets) { 
+        await this.core.database.query(`DELETE FROM mutual_relationships`)
+    }
+}

--- a/packages/backend/services/FeatureService.js
+++ b/packages/backend/services/FeatureService.js
@@ -93,7 +93,7 @@ module.exports = class FeatureService {
             'feat-491-mutual-friends': {
                 migration: new Feat491MutualFriendsMigration(core)
             },
-            'feat-495-slow-friends-list': {
+            'fix-495-slow-friends-list': {
                 migration: new Fix495SlowFriendsListMigration(core)
             },
             'video-uploads': {}

--- a/packages/backend/services/FeatureService.js
+++ b/packages/backend/services/FeatureService.js
@@ -30,6 +30,7 @@ const Feat408FlagUsersAndGroupsMigration = require('../migrations/Feat408FlagUse
 const Fix486UniqueConstraintMigration = require('../migrations/Fix486UniqueConstraintMigration')
 const Feat484FindActiveGroupsMigration = require('../migrations/Feat484FindActiveGroupsMigration')
 const Feat491MutualFriendsMigration = require('../migrations/Feat491MutualFriendsMigration')
+const Fix495SlowFriendsListMigration = require('../migrations/Fix495SlowFriendsListMigration')
 
 const ServiceError = require('../errors/ServiceError')
 const MigrationError = require('../errors/MigrationError')
@@ -91,6 +92,9 @@ module.exports = class FeatureService {
             },
             'feat-491-mutual-friends': {
                 migration: new Feat491MutualFriendsMigration(core)
+            },
+            'feat-495-slow-friends-list': {
+                migration: new Fix495SlowFriendsListMigration(core)
             },
             'video-uploads': {}
         }

--- a/packages/backend/services/MutualsService.js
+++ b/packages/backend/services/MutualsService.js
@@ -34,54 +34,6 @@ module.exports = class MutualsService {
         this.userRelationshipService = new UserRelationshipService(core)
     }
 
-    async getFriendMap(currentUser, list) {
-        // Build a dictionary of users in the target list who are friends of the current user.
-        const isFriend = {}
-        const targetRelationships = await this.userRelationshipDAO.selectUserRelationships({
-            where: `
-                user_relationships.status = 'confirmed' AND (
-                    ( user_relationships.user_id = $1 AND user_relationships.friend_id = ANY($2::uuid[]))
-                    OR ( user_relationships.friend_id = $1 AND user_relationships.user_id = ANY($2::uuid[]))
-                )
-            `,
-            params: [ currentUser.id, list ]})
-        for(const id of targetRelationships.list) {
-            const relationship = targetRelationships.dictionary[id]
-            if ( relationship.userId === currentUser.id ) {
-                isFriend[relationship.relationId] = true
-            } else {
-                isFriend[relationship.userId] = true
-            }
-        }
-
-        return isFriend
-    }
-
-    canCurrentUserViewMutualFriends(user, isFriend) {
-        // If the target has "viewMutualFriends" set to 'me', then remove
-        // them from the list, because `currentUser` cannot view their
-        // mutual friends.
-        if ( user.privacyViewMutualFriends === 'me' ) {
-            return false 
-        }
-
-        // If the target has "viewMutualFriends" set to 'friends', and `currentUser` does not
-        // have a friend relationship with them, then remove them from the list.
-        if ( user.privacyViewMutualFriends === 'friends' && isFriend === false) { 
-            return false
-        }
-
-        // `friend-of-friend` and `public` visibility are functionally the same
-        // for the purposes of this permission check.
-        //
-        // If they have mutual friends with visibility set to
-        // 'friends-of-friends', then we don't need to filter those friends. If
-        // they don't have mutual friends, then there's nothing to view, the
-        // query we're filtering will return empty.
-
-        return true
-    }
-
     async getMutualsForCurrentUserAndList(currentUser, list) {
         const results = await this.core.database.query(`
             SELECT 
@@ -91,8 +43,8 @@ module.exports = class MutualsService {
                 LEFT OUTER JOIN users mutual ON mutual_relationships.mutual_id = mutual.id
                 LEFT OUTER JOIN users target ON mutual_relationships.target_id = target.id
                 LEFT OUTER JOIN user_relationships ON 
-                    (mutual_relationships.current_id = user_relationships.user_id AND mutual_relationships.target_id = user_relationships.friend_id)
-                    OR (mutual_relationships.current_id = user_relationships.friend_id AND mutual_relationships.target_id = user_relationships.user_id)
+                    (mutual_relationships.current_id = user_relationships.user_id AND mutual_relationships.target_id = user_relationships.friend_id and user_relationships.status = 'confirmed)
+                    OR (mutual_relationships.current_id = user_relationships.friend_id AND mutual_relationships.target_id = user_relationships.user_id and user_relationships.status = 'confirmed')
             WHERE 
                 mutual_relationships.current_id = $1 
                 AND mutual_relationships.target_id = ANY($2::uuid[])
@@ -133,41 +85,69 @@ module.exports = class MutualsService {
     }
 
     async addMutualsForRelationship(userRelationship) {
-        const userFriendIds = await this.userRelationshipService.getFriendIdsForUser(userRelationship.userId)
-        const relationFriendIds = await this.userRelationshipService.getFriendIdsForUser(userRelationship.relationId)
+        // `userRelationship` is already confirmed and we don't necessarily
+        // want a row pointing back to the relationship itself.
+        const userFriendIds = await this.userRelationshipService.getFriendIdsForUser(userRelationship.userId).filter((id) => id !== userRelationship.relationId)
+        const relationFriendIds = await this.userRelationshipService.getFriendIdsForUser(userRelationship.relationId).filter((id) => id !== userRelationship.userId)
 
+        let query = ''
+        let params = []
+
+        //
         // All of user's friends gain user as a mutual with relation.
+        //
+        query = `INSERT INTO mutual_relationships (current_id, mutual_id, target_id ) VALUES `
+        params = []
         for(const friendId of userFriendIds) {
-            await this.core.database.query(`
-                INSERT INTO mutual_relationships (current_id, mutual_id, target_id )
-                    VALUES ($1, $2, $3) ON CONFLICT DO NOTHING
-            `, [ friendId, userRelationship.userId, userRelationship.relationId ])
+            query += `($${params.length+1}, $${params.length+2}, $${params.length+3}),`
+            params.push(friendId, userRelationship.userId, userRelationship.relationId)
         }
+        // Strip off the last comma.
+        query.substring(0,query.length-1)
+        query += ` ON CONFLICT DO NOTHING`
+        await this.core.database.query(query, params)
 
+        //
         // All of relation's friends gain relation as a mutual with user.
+        //
+        query = `INSERT INTO mutual_relationships (current_id, mutual_id, target_id ) VALUES `
+        params = []
         for(const friendId of relationFriendIds) {
-            await this.core.database.query(`
-                INSERT INTO mutual_relationships (current_id, mutual_id, target_id )
-                    VALUES ($1, $2, $3) ON CONFLICT DO NOTHING
-            `, [ friendId, userRelationship.relationId, userRelationship.userId])
+            query += `($${params.length+1}, $${params.length+2}, $${params.length+3}),`
+            params.push(friendId, userRelationship.relationId, userRelationship.userId)
         }
+        // Strip off the last comma.
+        query.substring(0,query.length-1)
+        query += ` ON CONFLICT DO NOTHING`
+        await this.core.database.query(query, params)
 
+        //
         // Relation gains user as a mutual with all of user's friends.
+        //
+        query = `INSERT INTO mutual_relationships (current_id, mutual_id, target_id ) VALUES `
+        params = []
         for(const friendId of userFriendIds) {
-            await this.core.database.query(`
-                INSERT INTO mutual_relationships (current_id, mutual_id, target_id )
-                    VALUES ($1, $2, $3) ON CONFLICT DO NOTHING
-            `, [ userRelationship.relationId, userRelationship.userId, friendId ])
-
+            query += `($${params.length+1}, $${params.length+2}, $${params.length+3}),`
+            params.push(userRelationship.relationId, userRelationship.userId, friendId)
         }
+        // Strip off the last comma.
+        query.substring(0,query.length-1)
+        query += ` ON CONFLICT DO NOTHING`
+        await this.core.database.query(query, params)
 
+        //
         // User gains relation as a mutual with all of relation's friends.
+        //
+        query = `INSERT INTO mutual_relationships (current_id, mutual_id, target_id ) VALUES `
+        params = []
         for(const friendId of relationFriendIds) {
-            await this.core.database.query(`
-                INSERT INTO mutual_relationships (current_id, mutual_id, target_id )
-                    VALUES ($1, $2, $3) ON CONFLICT DO NOTHING
-            `, [ userRelationship.userId, userRelationship.relationId, friendId ])
+            query += `($${params.length+1}, $${params.length+2}, $${params.length+3}),`
+            params.push(userRelationship.userId, userRelationship.relationId, friendId)
         }
+        // Strip off the last comma.
+        query.substring(0,query.length-1)
+        query += ` ON CONFLICT DO NOTHING`
+        await this.core.database.query(query, params)
     }
 
     async removeMutualsForRelationship(userRelationship) {

--- a/packages/backend/services/MutualsService.js
+++ b/packages/backend/services/MutualsService.js
@@ -118,74 +118,6 @@ module.exports = class MutualsService {
         }
 
         return dictionary
-
-        /*const targets = await this.userDAO.selectUsers({
-            where: `users.id = ANY($1::uuid[])`,
-            params: [ list ],
-            fields: 'all'
-        })
-
-        const isTargetFriend = await this.getFriendMap(currentUser, list)
-
-        const targetList = list.filter((id) =>  {
-            return this.canCurrentUserViewMutualFriends(targets.dictionary[id], (id in isTargetFriend))
-        })
-
-        const mutualsResults = await this.core.database.query(`
-            SELECT mutuals.current_id, mutuals.mutual_id, mutuals.target_id
-                FROM users,
-                LATERAL (
-                    SELECT 
-                            CASE
-                                WHEN c.user_id = $1 THEN c.user_id
-                                WHEN c.friend_id = $1 THEN c.friend_id
-                            END as current_id,
-                            CASE 
-                                WHEN c.user_id = $1 THEN c.friend_id
-                                WHEN c.friend_id = $1 THEN c.user_id
-                            END as mutual_id,
-                            CASE 
-                                WHEN t.user_id = users.id THEN t.user_id
-                                WHEN t.friend_id = users.id THEN t.friend_id
-                            END as target_id
-                        FROM user_relationships c
-                        JOIN user_relationships t 
-                            ON (c.user_id = $1 AND c.friend_id = t.user_id AND t.friend_id = users.id)
-                                OR (c.user_id = $1 AND c.friend_id = t.friend_id AND t.user_id = users.id)
-                                OR (c.friend_id = $1 AND c.user_id = t.user_id AND t.friend_id = users.id)
-                                OR (c.friend_id = $1 AND c.user_id = t.friend_id AND t.user_id = users.id)
-                        WHERE c.status = 'confirmed' AND t.status = 'confirmed'
-                ) as mutuals
-                WHERE users.id = ANY($2::uuid[])
-        `, [ currentUser.id, targetList])
-
-        if ( mutualsResults.rows.length <= 0 ) {
-            return { }
-        }
-
-        const mutualIds = mutualsResults.rows.map((r) => r.mutual_id) 
-
-        const mutuals = await this.userDAO.selectUsers({
-            where: `users.id = ANY($1::uuid[])`,
-            params: [ mutualIds ],
-            fields: 'all'
-        })
-
-        const isMutualFriend = await this.getFriendMap(currentUser, mutualIds) 
-        const visibleMutuals = mutualsResults.rows.filter((row) => {
-            return this.canCurrentUserViewMutualFriends(mutuals.dictionary[row.mutual_id], (row.mutual_id in isMutualFriend))
-        })
-
-        const dictionary = {}
-        for(const row of visibleMutuals) {
-            if ( ! ( row.target_id in dictionary ) ) {
-                dictionary[row.target_id] = []
-            }
-
-            dictionary[row.target_id].push(row.mutual_id)
-        }
-
-        return dictionary */
     }
 
     async hasMutuals(currentUser, userId) {
@@ -198,30 +130,6 @@ module.exports = class MutualsService {
         }
 
         return false
-
-    /*const results = await this.core.database.query(`
-            SELECT 
-                count(*) as count 
-                FROM user_relationships c
-                JOIN user_relationships t 
-                    ON (c.user_id = $1 AND c.friend_id = t.user_id AND t.friend_id = $2)
-                        OR (c.user_id = $1 AND c.friend_id = t.friend_id AND t.user_id = $2)
-                        OR (c.friend_id = $1 AND c.user_id = t.user_id AND t.friend_id = $2)
-                        OR (c.friend_id = $1 AND c.user_id = t.friend_id AND t.user_id = $2)
-                WHERE c.status = 'confirmed' AND t.status = 'confirmed'
-        `, [ currentUser.id, userId])
-
-        if ( results.rows.length <= 0 ) {
-            return false
-        }
-
-        if ( results.rows[0].count <= 0 ) {
-            return false
-        } else if ( results.rows[0].count >= 1 ) {
-            return true
-        }
-
-        return false*/
     }
 
     async addMutualsForRelationship(userRelationship) {

--- a/packages/backend/services/MutualsService.js
+++ b/packages/backend/services/MutualsService.js
@@ -21,6 +21,8 @@
 const UserDAO = require('../daos/UserDAO')
 const UserRelationshipDAO = require('../daos/UserRelationshipDAO')
 
+const UserRelationshipService = require('./UserRelationshipService')
+
 module.exports = class MutualsService {
 
     constructor(core) {
@@ -28,6 +30,8 @@ module.exports = class MutualsService {
 
         this.userDAO = new UserDAO(core)
         this.userRelationshipDAO = new UserRelationshipDAO(core)
+
+        this.userRelationshipService = new UserRelationshipService(core)
     }
 
     async getFriendMap(currentUser, list) {
@@ -79,7 +83,43 @@ module.exports = class MutualsService {
     }
 
     async getMutualsForCurrentUserAndList(currentUser, list) {
-        const targets = await this.userDAO.selectUsers({
+        const results = await this.core.database.query(`
+            SELECT 
+                mutual_relationships.target_id as target_id,
+                mutual_relationships.mutual_id as mutual_id
+            FROM mutual_relationships
+                LEFT OUTER JOIN users mutual ON mutual_relationships.mutual_id = mutual.id
+                LEFT OUTER JOIN users target ON mutual_relationships.target_id = target.id
+                LEFT OUTER JOIN user_relationships ON 
+                    (mutual_relationships.current_id = user_relationships.user_id AND mutual_relationships.target_id = user_relationships.friend_id)
+                    OR (mutual_relationships.current_id = user_relationships.friend_id AND mutual_relationships.target_id = user_relationships.user_id)
+            WHERE 
+                mutual_relationships.current_id = $1 
+                AND mutual_relationships.target_id = ANY($2::uuid[])
+                AND mutual.privacy__view_mutual_friends != 'me'
+                AND ( 
+                    ( target.privacy__view_mutual_friends = 'friends' AND user_relationships.id IS NOT NULL)
+                    OR target.privacy__view_mutual_friends = 'friends-of-friends'
+                    OR target.privacy__view_mutual_friends = 'public'
+                )
+        `, [currentUser.id, list])
+
+        if ( results.rows.length <= 0 ) {
+            return {}
+        }
+
+        const dictionary = {}
+        for(const row of results.rows) {
+            if ( ! ( row.target_id in dictionary) ) {
+                dictionary[row.target_id] = []
+            }
+
+            dictionary[row.target_id].push(row.mutual_id)
+        }
+
+        return dictionary
+
+        /*const targets = await this.userDAO.selectUsers({
             where: `users.id = ANY($1::uuid[])`,
             params: [ list ],
             fields: 'all'
@@ -145,11 +185,21 @@ module.exports = class MutualsService {
             dictionary[row.target_id].push(row.mutual_id)
         }
 
-        return dictionary 
+        return dictionary */
     }
 
     async hasMutuals(currentUser, userId) {
         const results = await this.core.database.query(`
+            SELECT mutual_id FROM mutual_relationships WHERE current_id = $1 AND target_id = $2
+        `, [ currentUser.id, userId ])
+
+        if ( results.rows.length > 0 ) {
+            return true
+        }
+
+        return false
+
+    /*const results = await this.core.database.query(`
             SELECT 
                 count(*) as count 
                 FROM user_relationships c
@@ -171,7 +221,69 @@ module.exports = class MutualsService {
             return true
         }
 
-        return false
+        return false*/
+    }
+
+    async addMutualsForRelationship(userRelationship) {
+        const userFriendIds = await this.userRelationshipService.getFriendIdsForUser(userRelationship.userId)
+        const relationFriendIds = await this.userRelationshipService.getFriendIdsForUser(userRelationship.relationId)
+
+        // All of user's friends gain user as a mutual with relation.
+        for(const friendId of userFriendIds) {
+            await this.core.database.query(`
+                INSERT INTO mutual_relationships (current_id, mutual_id, target_id )
+                    VALUES ($1, $2, $3) ON CONFLICT DO NOTHING
+            `, [ friendId, userRelationship.userId, userRelationship.relationId ])
+        }
+
+        // All of relation's friends gain relation as a mutual with user.
+        for(const friendId of relationFriendIds) {
+            await this.core.database.query(`
+                INSERT INTO mutual_relationships (current_id, mutual_id, target_id )
+                    VALUES ($1, $2, $3) ON CONFLICT DO NOTHING
+            `, [ friendId, userRelationship.relationId, userRelationship.userId])
+        }
+
+        // Relation gains user as a mutual with all of user's friends.
+        for(const friendId of userFriendIds) {
+            await this.core.database.query(`
+                INSERT INTO mutual_relationships (current_id, mutual_id, target_id )
+                    VALUES ($1, $2, $3) ON CONFLICT DO NOTHING
+            `, [ userRelationship.relationId, userRelationship.userId, friendId ])
+
+        }
+
+        // User gains relation as a mutual with all of relation's friends.
+        for(const friendId of relationFriendIds) {
+            await this.core.database.query(`
+                INSERT INTO mutual_relationships (current_id, mutual_id, target_id )
+                    VALUES ($1, $2, $3) ON CONFLICT DO NOTHING
+            `, [ userRelationship.userId, userRelationship.relationId, friendId ])
+        }
+    }
+
+    async removeMutualsForRelationship(userRelationship) {
+        // All of user's friends lose user as a mutual with relation.
+        await this.core.database.query(`
+            DELETE FROM mutual_relationships WHERE mutual_id = $1 AND target_id = $2
+        `, [ userRelationship.userId, userRelationship.relationId ])
+
+        // All of relation's friends lose relation as a mutual with user.
+        await this.core.database.query(`
+            DELETE FROM mutual_relationships WHERE mutual_id = $1 AND target_id = $2
+        `, [ userRelationship.relationId, userRelationship.userId])
+
+        // Relation loses user as a mutual with all of user's friends.
+        await this.core.database.query(`
+            DELETE FROM mutual_relationships WHERE current_id = $1 AND mutual_id = $2
+        `, [ userRelationship.relationId, userRelationship.userId ])
+
+
+        // User loses relation as a mutual with all of relation's friends.
+        await this.core.database.query(`
+            DELETE FROM mutual_relationships WHERE current_id = $1 AND mutual_id = $2
+        `, [ userRelationship.userId, userRelationship.relationId ])
+
     }
 
 

--- a/packages/backend/services/MutualsService.js
+++ b/packages/backend/services/MutualsService.js
@@ -35,6 +35,11 @@ module.exports = class MutualsService {
     }
 
     async getMutualsForCurrentUserAndList(currentUser, list) {
+        if ( ! this.core.features.has('fix-495-slow-friends-list') ) {
+            return {}
+        }
+
+
         const results = await this.core.database.query(`
             SELECT 
                 mutual_relationships.target_id as target_id,
@@ -73,6 +78,10 @@ module.exports = class MutualsService {
     }
 
     async hasMutuals(currentUser, userId) {
+        if ( ! this.core.features.has('fix-495-slow-friends-list') ) {
+            return false
+        }
+
         const results = await this.core.database.query(`
             SELECT mutual_id FROM mutual_relationships WHERE current_id = $1 AND target_id = $2
         `, [ currentUser.id, userId ])

--- a/packages/backend/services/MutualsService.js
+++ b/packages/backend/services/MutualsService.js
@@ -43,7 +43,7 @@ module.exports = class MutualsService {
                 LEFT OUTER JOIN users mutual ON mutual_relationships.mutual_id = mutual.id
                 LEFT OUTER JOIN users target ON mutual_relationships.target_id = target.id
                 LEFT OUTER JOIN user_relationships ON 
-                    (mutual_relationships.current_id = user_relationships.user_id AND mutual_relationships.target_id = user_relationships.friend_id and user_relationships.status = 'confirmed)
+                    (mutual_relationships.current_id = user_relationships.user_id AND mutual_relationships.target_id = user_relationships.friend_id and user_relationships.status = 'confirmed')
                     OR (mutual_relationships.current_id = user_relationships.friend_id AND mutual_relationships.target_id = user_relationships.user_id and user_relationships.status = 'confirmed')
             WHERE 
                 mutual_relationships.current_id = $1 
@@ -87,8 +87,8 @@ module.exports = class MutualsService {
     async addMutualsForRelationship(userRelationship) {
         // `userRelationship` is already confirmed and we don't necessarily
         // want a row pointing back to the relationship itself.
-        const userFriendIds = await this.userRelationshipService.getFriendIdsForUser(userRelationship.userId).filter((id) => id !== userRelationship.relationId)
-        const relationFriendIds = await this.userRelationshipService.getFriendIdsForUser(userRelationship.relationId).filter((id) => id !== userRelationship.userId)
+        const userFriendIds = (await this.userRelationshipService.getFriendIdsForUser(userRelationship.userId)).filter((id) => id !== userRelationship.relationId)
+        const relationFriendIds = (await this.userRelationshipService.getFriendIdsForUser(userRelationship.relationId)).filter((id) => id !== userRelationship.userId)
 
         let query = ''
         let params = []
@@ -96,58 +96,66 @@ module.exports = class MutualsService {
         //
         // All of user's friends gain user as a mutual with relation.
         //
-        query = `INSERT INTO mutual_relationships (current_id, mutual_id, target_id ) VALUES `
-        params = []
-        for(const friendId of userFriendIds) {
-            query += `($${params.length+1}, $${params.length+2}, $${params.length+3}),`
-            params.push(friendId, userRelationship.userId, userRelationship.relationId)
+        if ( userFriendIds.length > 0 ) {
+            query = `INSERT INTO mutual_relationships (current_id, mutual_id, target_id ) VALUES `
+            params = []
+            for(const friendId of userFriendIds) {
+                query += `($${params.length+1}, $${params.length+2}, $${params.length+3}),`
+                params.push(friendId, userRelationship.userId, userRelationship.relationId)
+            }
+            // Strip off the last comma.
+            query = query.substring(0,query.length-1)
+            query += ` ON CONFLICT DO NOTHING`
+            await this.core.database.query(query, params)
         }
-        // Strip off the last comma.
-        query.substring(0,query.length-1)
-        query += ` ON CONFLICT DO NOTHING`
-        await this.core.database.query(query, params)
 
         //
         // All of relation's friends gain relation as a mutual with user.
         //
-        query = `INSERT INTO mutual_relationships (current_id, mutual_id, target_id ) VALUES `
-        params = []
-        for(const friendId of relationFriendIds) {
-            query += `($${params.length+1}, $${params.length+2}, $${params.length+3}),`
-            params.push(friendId, userRelationship.relationId, userRelationship.userId)
+        if ( relationFriendIds.length > 0 ) {
+            query = `INSERT INTO mutual_relationships (current_id, mutual_id, target_id ) VALUES `
+            params = []
+            for(const friendId of relationFriendIds) {
+                query += `($${params.length+1}, $${params.length+2}, $${params.length+3}),`
+                params.push(friendId, userRelationship.relationId, userRelationship.userId)
+            }
+            // Strip off the last comma.
+            query = query.substring(0,query.length-1)
+            query += ` ON CONFLICT DO NOTHING`
+            await this.core.database.query(query, params)
         }
-        // Strip off the last comma.
-        query.substring(0,query.length-1)
-        query += ` ON CONFLICT DO NOTHING`
-        await this.core.database.query(query, params)
 
         //
         // Relation gains user as a mutual with all of user's friends.
         //
-        query = `INSERT INTO mutual_relationships (current_id, mutual_id, target_id ) VALUES `
-        params = []
-        for(const friendId of userFriendIds) {
-            query += `($${params.length+1}, $${params.length+2}, $${params.length+3}),`
-            params.push(userRelationship.relationId, userRelationship.userId, friendId)
+        if ( userFriendIds.length > 0 ) {
+            query = `INSERT INTO mutual_relationships (current_id, mutual_id, target_id ) VALUES `
+            params = []
+            for(const friendId of userFriendIds) {
+                query += `($${params.length+1}, $${params.length+2}, $${params.length+3}),`
+                params.push(userRelationship.relationId, userRelationship.userId, friendId)
+            }
+            // Strip off the last comma.
+            query = query.substring(0,query.length-1)
+            query += ` ON CONFLICT DO NOTHING`
+            await this.core.database.query(query, params)
         }
-        // Strip off the last comma.
-        query.substring(0,query.length-1)
-        query += ` ON CONFLICT DO NOTHING`
-        await this.core.database.query(query, params)
 
         //
         // User gains relation as a mutual with all of relation's friends.
         //
-        query = `INSERT INTO mutual_relationships (current_id, mutual_id, target_id ) VALUES `
-        params = []
-        for(const friendId of relationFriendIds) {
-            query += `($${params.length+1}, $${params.length+2}, $${params.length+3}),`
-            params.push(userRelationship.userId, userRelationship.relationId, friendId)
+        if ( relationFriendIds.length > 0 ) {
+            query = `INSERT INTO mutual_relationships (current_id, mutual_id, target_id ) VALUES `
+            params = []
+            for(const friendId of relationFriendIds) {
+                query += `($${params.length+1}, $${params.length+2}, $${params.length+3}),`
+                params.push(userRelationship.userId, userRelationship.relationId, friendId)
+            }
+            // Strip off the last comma.
+            query = query.substring(0,query.length-1)
+            query += ` ON CONFLICT DO NOTHING`
+            await this.core.database.query(query, params)
         }
-        // Strip off the last comma.
-        query.substring(0,query.length-1)
-        query += ` ON CONFLICT DO NOTHING`
-        await this.core.database.query(query, params)
     }
 
     async removeMutualsForRelationship(userRelationship) {

--- a/packages/backend/services/UserRelationshipService.js
+++ b/packages/backend/services/UserRelationshipService.js
@@ -1,0 +1,44 @@
+/******************************************************************************
+ *
+ *  Communities -- Non-profit, cooperative social media 
+ *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+module.exports = class UserRelationshipService {
+
+    constructor(core) {
+        this.core = core
+    }
+
+    async getFriendIdsForUser(userId) {
+        const friendResults = await this.core.database.query(`
+            SELECT
+                CASE
+                    WHEN user_id = $1 THEN friend_id
+                    WHEN friend_id = $1 THEN user_id
+                END AS friend_id
+            FROM user_relationships WHERE status = 'confirmed' AND (user_id = $1 OR friend_id = $1)
+        `, [ userId ])
+
+        if ( friendResults.rows.length <= 0 ) {
+            return []
+        }
+
+        const friendIds = friendResults.rows.map((r) => r.friend_id)
+        return friendIds
+    }
+}

--- a/web-application/server/controllers/UserRelationshipController.js
+++ b/web-application/server/controllers/UserRelationshipController.js
@@ -252,6 +252,15 @@ module.exports = class UserRelationshipController {
         // If we're blocking a user, then delete the existing relationship.
         // We're replacing it with a block relationship.
         if ( status === 'blocked' && existing !== null ) {
+            // We need to remove the mutuals here, because we're blocking the
+            // user but then setting "existing" to null.
+            if ( existing.status === 'confirmed' ) {
+                await this.core.queues['remove-mutuals-for-relationship'].add({ 
+                    session: { user: currentUser }, 
+                    relationship: existing 
+                }, { attempts: 2 })
+            }
+
             await this.userRelationshipDAO.deleteUserRelationship(existing)
             existing = null
         }

--- a/web-application/server/controllers/UserRelationshipController.js
+++ b/web-application/server/controllers/UserRelationshipController.js
@@ -296,6 +296,11 @@ module.exports = class UserRelationshipController {
                     `We confirmed the relationship between you and ${relationId}, but it wasn't there when we queried it. Please report bug.`)
             }
 
+            await this.core.queues['add-mutuals-for-relationship'].add({ 
+                session: { user: currentUser }, 
+                relationship: entity
+            }, { attempts: 2 })
+
             await this.notificationService.sendNotifications(
                 currentUser, 
                 'UserRelationship:update',
@@ -478,6 +483,11 @@ module.exports = class UserRelationshipController {
                 `We created the relationship between you and ${relationId}, but it wasn't there when we queried it. Please report bug.`)
         }
 
+        await this.core.queues['add-mutuals-for-relationship'].add({ 
+            session: { user: currentUser }, 
+            relationship: entity
+        }, { attempts: 2 })
+
         await this.notificationService.sendNotifications(
             currentUser, 
             'UserRelationship:update',
@@ -529,6 +539,11 @@ module.exports = class UserRelationshipController {
         const existing = existingResults.dictionary[existingResults.list[0]]
 
         await this.userRelationshipDAO.deleteUserRelationship(existing)
+
+        await this.core.queues['remove-mutuals-for-relationship'].add({ 
+            session: { user: currentUser }, 
+            relationship: existing 
+        }, { attempts: 2 })
 
         const relations = await this.getRelations(currentUser, userId, existingResults)
 

--- a/web-application/server/controllers/UserRelationshipController.js
+++ b/web-application/server/controllers/UserRelationshipController.js
@@ -583,11 +583,9 @@ module.exports = class UserRelationshipController {
             }, { attempts: 2 })
         }
 
-        const relations = await this.getRelations(currentUser, userId, existingResults)
-
         response.status(200).json({
             entity: existing,
-            relations: relations
+            relations: {} 
         })
     }
 

--- a/web-application/server/controllers/UserRelationshipController.js
+++ b/web-application/server/controllers/UserRelationshipController.js
@@ -296,10 +296,17 @@ module.exports = class UserRelationshipController {
                     `We confirmed the relationship between you and ${relationId}, but it wasn't there when we queried it. Please report bug.`)
             }
 
-            await this.core.queues['add-mutuals-for-relationship'].add({ 
-                session: { user: currentUser }, 
-                relationship: entity
-            }, { attempts: 2 })
+            if ( existing.status !== 'confirmed' && entity.status === 'confirmed' ) {
+                await this.core.queues['add-mutuals-for-relationship'].add({ 
+                    session: { user: currentUser }, 
+                    relationship: entity
+                }, { attempts: 2 })
+            } else if ( existing.status === 'confirmed' && entity.status !== 'confirmed' ) {
+                await this.core.queues['remove-mutuals-for-relationship'].add({ 
+                    session: { user: currentUser }, 
+                    relationship: entity 
+                }, { attempts: 2 })
+            }
 
             await this.notificationService.sendNotifications(
                 currentUser, 
@@ -351,7 +358,7 @@ module.exports = class UserRelationshipController {
                     `We created the relationship between you and ${relationId}, but it wasn't there when we queried it. Please report bug.`)
             }
           
-            if ( userRelationship.status !== 'blocked' ) {
+            if ( entity.status !== 'blocked' ) {
                 await this.notificationService.sendNotifications(
                     currentUser, 
                     'UserRelationship:create',
@@ -360,6 +367,19 @@ module.exports = class UserRelationshipController {
                         relationId: relationId
                     }
                 )
+            }
+
+
+            // This really shouldn't happen.  But just in case there's a case
+            // where it does happen someday, lets make sure we cover that case.
+            //
+            // In the case where status is "blocked", we don't need to do
+            // anything, because there is no pre-existing relationship.
+            if ( entity.status === 'confirmed' ) {
+                await this.core.queues['add-mutuals-for-relationship'].add({ 
+                    session: { user: currentUser }, 
+                    relationship: entity
+                }, { attempts: 2 })
             }
 
             const relations = await this.getRelations(currentUser, userId, results)
@@ -483,10 +503,17 @@ module.exports = class UserRelationshipController {
                 `We created the relationship between you and ${relationId}, but it wasn't there when we queried it. Please report bug.`)
         }
 
-        await this.core.queues['add-mutuals-for-relationship'].add({ 
-            session: { user: currentUser }, 
-            relationship: entity
-        }, { attempts: 2 })
+        if ( existing.status !== 'confirmed' && entity.status === 'confirmed' ) {
+            await this.core.queues['add-mutuals-for-relationship'].add({ 
+                session: { user: currentUser }, 
+                relationship: entity
+            }, { attempts: 2 })
+        } else if ( existing.status === 'confirmed' && entity.status !== 'confirmed' ) {
+            await this.core.queues['remove-mutuals-for-relationship'].add({ 
+                session: { user: currentUser }, 
+                relationship: entity 
+            }, { attempts: 2 })
+        }
 
         await this.notificationService.sendNotifications(
             currentUser, 
@@ -540,10 +567,12 @@ module.exports = class UserRelationshipController {
 
         await this.userRelationshipDAO.deleteUserRelationship(existing)
 
-        await this.core.queues['remove-mutuals-for-relationship'].add({ 
-            session: { user: currentUser }, 
-            relationship: existing 
-        }, { attempts: 2 })
+        if ( existing.status === 'confirmed' ) {
+            await this.core.queues['remove-mutuals-for-relationship'].add({ 
+                session: { user: currentUser }, 
+                relationship: existing 
+            }, { attempts: 2 })
+        }
 
         const relations = await this.getRelations(currentUser, userId, existingResults)
 

--- a/worker/index.js
+++ b/worker/index.js
@@ -30,6 +30,9 @@ const getResizeImageJob = require('./jobs/resizeImage')
 const getSendNotificationsJob = require('./jobs/sendNotifications')
 const getProcessVideoJob = require('./jobs/processVideo')
 
+const getAddMutualsForRelationship = require('./jobs/addMutualsForRelationship')
+const getRemoveMutualsForRelationship = require('./jobs/removeMutualsForRelationship')
+
 const configDefinition = require('./config')
 
 let queue = 'general'
@@ -57,16 +60,30 @@ async function initialize() {
     const features = await featureService.getEnabledFeatures()
     core.features = new FeatureFlags(features)
 
+    // You can't control parallelism by the job in a single queue.  The only
+    // way to control parallelism is by creating a queue per job type. The
+    // 'process-video' job will use all of the resources on its box, so each
+    // job needs to be isolated to its own vm.  To do this, we have to make it
+    // its own queue, and then use placement constraints to ensure that
+    // particular worker gets a whole node to itself.
+    //
+    // NOTE: When adding a new job, don't forget to create the queue in `backend/core.js`
     if ( queue === 'resize-image' ) {
         core.queues['resize-image'].process(getResizeImageJob(core))
     } else if ( queue === 'process-video' ) {
         core.queues['process-video'].process(getProcessVideoJob(core))
     } else if ( queue === 'send-notifications' ) {
         core.queues['send-notifications'].process(100, getSendNotificationsJob(core))
+    } else if ( queue === 'add-mutuals-for-relationship' ) {
+        core.queues['add-mutuals-for-relationship'].process(10, getAddMutualsForRelationship(core))
+    } else if ( queue === 'remove-mutuals-for-relationship' ) {
+        core.queues['remove-mutuals-for-relationship'].process(10, getRemoveMutualsForRelationship(core))
     } else {
         core.queues['send-notifications'].process(100, getSendNotificationsJob(core))
         core.queues['process-video'].process(getProcessVideoJob(core))
         core.queues['resize-image'].process(getResizeImageJob(core))
+        core.queues['add-mutuals-for-relationship'].process(10, getAddMutualsForRelationship(core))
+        core.queues['remove-mutuals-for-relationship'].process(10, getRemoveMutualsForRelationship(core))
     }
 
     core.logger.info(`Initialized and listening to queue '${queue}'...`)

--- a/worker/jobs/addMutualsForRelationship.js
+++ b/worker/jobs/addMutualsForRelationship.js
@@ -1,0 +1,41 @@
+/******************************************************************************
+ *
+ *  Communities -- Non-profit, cooperative social media 
+ *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+const { MutualsService } = require('@communities/backend')
+
+const getAddMutualsForRelationship = function(core) {
+    return async function(job, done) {
+        core.logger.id = `Add Mutuals for Relationship: ${job.id}`
+
+        const currentUser = job.data.session.user
+        const relationship = job.data.relationship
+
+        core.logger.info(`Beginning job 'add-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
+        try {
+            const mutualsService = new MutualsService(core)
+            await mutualsService.addMutualsForRelationship(relationship)
+        } catch (error) {
+            core.logger.error(error)
+        }
+        core.logger.info(`Finishing job 'add-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
+    }
+}
+
+module.exports = getAddMutualsForRelationship 

--- a/worker/jobs/addMutualsForRelationship.js
+++ b/worker/jobs/addMutualsForRelationship.js
@@ -28,6 +28,7 @@ const getAddMutualsForRelationship = function(core) {
             if ( ! core.features.has('fix-495-slow-friends-list') ) {
                 core.logger.info(`Cannot run job 'add-mutuals-for-relationship' before feature is enabled.`)
                 done(null)
+                return
             }
 
             const currentUser = job.data.session.user

--- a/worker/jobs/addMutualsForRelationship.js
+++ b/worker/jobs/addMutualsForRelationship.js
@@ -22,19 +22,25 @@ const { MutualsService } = require('@communities/backend')
 
 const getAddMutualsForRelationship = function(core) {
     return async function(job, done) {
-        core.logger.id = `Add Mutuals for Relationship: ${job.id}`
-
-        const currentUser = job.data.session.user
-        const relationship = job.data.relationship
-
-        core.logger.info(`Beginning job 'add-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
         try {
+            core.logger.id = `Add Mutuals for Relationship: ${job.id}`
+
+            const currentUser = job.data.session.user
+            const relationship = job.data.relationship
+
+            core.logger.info(`Beginning job 'add-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
+
             const mutualsService = new MutualsService(core)
             await mutualsService.addMutualsForRelationship(relationship)
+
+            core.logger.info(`Finishing job 'add-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
+            core.logger.id = 'core'
+            done(null)
         } catch (error) {
             core.logger.error(error)
+            core.logger.id = 'core'
+            done(error)
         }
-        core.logger.info(`Finishing job 'add-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
     }
 }
 

--- a/worker/jobs/addMutualsForRelationship.js
+++ b/worker/jobs/addMutualsForRelationship.js
@@ -25,6 +25,11 @@ const getAddMutualsForRelationship = function(core) {
         try {
             core.logger.id = `Add Mutuals for Relationship: ${job.id}`
 
+            if ( ! core.features.has('fix-495-slow-friends-list') ) {
+                core.logger.info(`Cannot run job 'add-mutuals-for-relationship' before feature is enabled.`)
+                done(null)
+            }
+
             const currentUser = job.data.session.user
             const relationship = job.data.relationship
 

--- a/worker/jobs/removeMutualsForRelationship.js
+++ b/worker/jobs/removeMutualsForRelationship.js
@@ -23,10 +23,16 @@ const { MutualsService } = require('@communities/backend')
 const getRemoveMutualsForRelationship = function(core) {
     return async function(job, done) {
         try {
+            core.logger.id = `Remove Mutuals For Relationship: ${job.id}`
+
+            if ( ! core.features.has('fix-495-slow-friends-list') ) {
+                core.logger.info(`Cannot run job 'add-mutuals-for-relationship' before feature is enabled.`)
+                done(null)
+            }
+
             const currentUser = job.data.session.user
             const relationship = job.data.relationship
 
-            core.logger.id = `Remove Mutuals For Relationship: ${job.id}`
             core.logger.info(`Beginning job 'remove-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
 
             const mutualsService = new MutualsService(core)

--- a/worker/jobs/removeMutualsForRelationship.js
+++ b/worker/jobs/removeMutualsForRelationship.js
@@ -26,8 +26,9 @@ const getRemoveMutualsForRelationship = function(core) {
             core.logger.id = `Remove Mutuals For Relationship: ${job.id}`
 
             if ( ! core.features.has('fix-495-slow-friends-list') ) {
-                core.logger.info(`Cannot run job 'add-mutuals-for-relationship' before feature is enabled.`)
+                core.logger.info(`Cannot run job 'remove-mutuals-for-relationship' before feature is enabled.`)
                 done(null)
+                return
             }
 
             const currentUser = job.data.session.user

--- a/worker/jobs/removeMutualsForRelationship.js
+++ b/worker/jobs/removeMutualsForRelationship.js
@@ -22,19 +22,24 @@ const { MutualsService } = require('@communities/backend')
 
 const getRemoveMutualsForRelationship = function(core) {
     return async function(job, done) {
-        core.logger.id = `Remove Mutuals For Relationship: ${job.id}`
-
-        const currentUser = job.data.session.user
-        const relationship = job.data.relationship
-
-        core.logger.info(`Beginning job 'remove-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
         try {
+            const currentUser = job.data.session.user
+            const relationship = job.data.relationship
+
+            core.logger.id = `Remove Mutuals For Relationship: ${job.id}`
+            core.logger.info(`Beginning job 'remove-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
+
             const mutualsService = new MutualsService(core)
             await mutualsService.removeMutualsForRelationship(relationship)
+
+            core.logger.info(`Finishing job 'remove-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
+            core.logger.id = 'core'
+            done(null)
         } catch (error) {
             core.logger.error(error)
+            core.logger.id = 'core'
+            done(error)
         }
-        core.logger.info(`Finishing job 'remove-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
     }
 }
 

--- a/worker/jobs/removeMutualsForRelationship.js
+++ b/worker/jobs/removeMutualsForRelationship.js
@@ -1,0 +1,41 @@
+/******************************************************************************
+ *
+ *  Communities -- Non-profit, cooperative social media 
+ *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+const { MutualsService } = require('@communities/backend')
+
+const getRemoveMutualsForRelationship = function(core) {
+    return async function(job, done) {
+        core.logger.id = `Remove Mutuals For Relationship: ${job.id}`
+
+        const currentUser = job.data.session.user
+        const relationship = job.data.relationship
+
+        core.logger.info(`Beginning job 'remove-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
+        try {
+            const mutualsService = new MutualsService(core)
+            await mutualsService.removeMutualsForRelationship(relationship)
+        } catch (error) {
+            core.logger.error(error)
+        }
+        core.logger.info(`Finishing job 'remove-mutuals-for-relationship' for User(${currentUser.id}) and Relationship(${relationship.id}).`)
+    }
+}
+
+module.exports = getRemoveMutualsForRelationship 

--- a/worker/jobs/sendNotifications.js
+++ b/worker/jobs/sendNotifications.js
@@ -21,11 +21,10 @@ const { Logger, NotificationWorker } = require('@communities/backend')
 
 const getSendNotificationsJob = function(core) {
     return async function(job, done) {
-        const logger = new Logger(core.logger.level, `send-notifications: ${job.id}`)
-        logger.info(`Beginning job 'send-notifications' of '${job.data.type}' for User(${job.data.currentUser.id}).`)
-        logger.verbose(`Data: `, job.data)
-
         try {
+            const logger = new Logger(core.logger.level, `send-notifications: ${job.id}`)
+            logger.info(`Beginning job 'send-notifications' of '${job.data.type}' for User(${job.data.currentUser.id}).`)
+
             job.progress({ step: 'initializing', stepDescription: `Initializing...`, progress: 0 })
 
             const notificationWorker = new NotificationWorker(core, logger)
@@ -34,8 +33,7 @@ const getSendNotificationsJob = function(core) {
 
             job.progress({ step: 'complete', stepDescription: `Complete!`, progress: 100 })
 
-            core.logger.info(`Finished job 'send-notifications' of '${job.data.type}' for user ${job.data.currentUser.id}.`)
-            core.logger.id = 'core' 
+            logger.info(`Finished job 'send-notifications' of '${job.data.type}' for user ${job.data.currentUser.id}.`)
             done(null)
         } catch (error) {
             core.logger.error(error)


### PR DESCRIPTION
The query to calculate mutual friends on the fly is too slow and it's making all user and user relationships queries too slow.

We're switching to an approach where we calculate the mutual friends in the background whenever a relationship changes and cache it in a tagging table.

Resolves #495