### PR TITLE
fix: check for local storage availability

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -96,6 +96,8 @@ services:
       - ./packages:/packages
       - ./packages/backend:/src/node_modules/@communities/backend
       - ./packages/shared:/src/node_modules/@communities/shared
+      # --- Temp directory for file processing ---
+      - ./worker/tmp:/src/tmp
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
@@ -151,6 +153,8 @@ services:
       - ./packages/backend:/src/node_modules/@communities/backend
       - ./packages/shared:/src/node_modules/@communities/shared
       - ./packages/session:/src/node_modules/@communities/session
+      # --- Temp directory for image uploads ---
+      - ./web-application/tmp:/src/tmp
     restart: unless-stopped
 
 # The CodeArtifact token is read from the CODEARTIFACT_AUTH_TOKEN host env var

--- a/web-application/client/components/posts/Post/PostComments/PostComments.js
+++ b/web-application/client/components/posts/Post/PostComments/PostComments.js
@@ -1,5 +1,28 @@
-import React, { useState, useEffect } from 'react'
+/******************************************************************************
+ *
+ *  Communities -- Non-profit, cooperative social media 
+ *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+import { useState, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
+
+import logger from '/logger'
+
+import { isLocalStorageAvailable } from '/lib/localStorage'
 
 import { startPostCommentEdit } from '/state/PostComment'
 
@@ -32,18 +55,24 @@ const PostComments = function({ postId, expanded }) {
     }, [])
 
     useEffect(function() {
-        if ( post !== null ) {
-            for(const commentId of post.comments) {
-                const editDraft = localStorage.getItem(`commentDraft.${postId}.${commentId}`)
-                if ( editDraft && ! (commentId in editing)) {
-                    dispatch(startPostCommentEdit(commentId))
-                    setShowComments(true)
-                }
-            }
+        if ( isLocalStorageAvailable() ) {
+            try { 
+                if ( post !== null ) {
+                    for(const commentId of post.comments) {
+                        const editDraft = localStorage.getItem(`commentDraft.${postId}.${commentId}`)
+                        if ( editDraft && ! (commentId in editing)) {
+                            dispatch(startPostCommentEdit(commentId))
+                            setShowComments(true)
+                        }
+                    }
 
-            const draft = localStorage.getItem(`commentDraft.${postId}`)
-            if ( draft ) {
-                setShowComments(true)
+                    const draft = localStorage.getItem(`commentDraft.${postId}`)
+                    if ( draft ) {
+                        setShowComments(true)
+                    }
+                }
+            } catch (error) {
+                logger.error(error)
             }
         }
     }, [ postId, post ])
@@ -61,7 +90,14 @@ const PostComments = function({ postId, expanded }) {
     let commentViews = []
     if ( post ) {
         for (const commentId of post.comments ) {
-            const draftEdit = localStorage.getItem(`commentDraft.${postId}.${commentId}`)
+            let draftEdit = null
+            if ( isLocalStorageAvailable() ) {
+                try { 
+                    draftEdit = localStorage.getItem(`commentDraft.${postId}.${commentId}`)
+                } catch (error) {
+                    logger.error(error)
+                }
+            }
             if ( draftEdit || (commentId in editing) ) {
                 commentViews.push(<PostCommentForm key={commentId} postId={postId} commentId={commentId} groupId={ post.groupId } setShowComments={setShowComments} />)
             } else {

--- a/web-application/client/components/posts/Post/PostComments/PostComments.js
+++ b/web-application/client/components/posts/Post/PostComments/PostComments.js
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
- *  Communities -- Non-profit, cooperative social media 
- *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *  Communities -- Non-profit, cooperative social media
+ *  Copyright (C) 2022 - 2024 Daniel Bingham
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published
@@ -56,7 +56,7 @@ const PostComments = function({ postId, expanded }) {
 
     useEffect(function() {
         if ( isLocalStorageAvailable() ) {
-            try { 
+            try {
                 if ( post !== null ) {
                     for(const commentId of post.comments) {
                         const editDraft = localStorage.getItem(`commentDraft.${postId}.${commentId}`)
@@ -92,7 +92,7 @@ const PostComments = function({ postId, expanded }) {
         for (const commentId of post.comments ) {
             let draftEdit = null
             if ( isLocalStorageAvailable() ) {
-                try { 
+                try {
                     draftEdit = localStorage.getItem(`commentDraft.${postId}.${commentId}`)
                 } catch (error) {
                     logger.error(error)
@@ -112,7 +112,7 @@ const PostComments = function({ postId, expanded }) {
             { showComments && post.comments.length > 0 && <div className="show-comments">
                 <a href="" onClick={(e) => { e.preventDefault(); setShowComments(false)}}>Hide { post.comments.length } comments.</a>
             </div> }
-            <PostCommentForm postId={postId} groupId={ post?.groupId } setShowComments={setShowComments} /> 
+            <PostCommentForm postId={postId} groupId={ post?.groupId } setShowComments={setShowComments} />
         </div>
     )
 }

--- a/web-application/client/components/posts/PostCommentForm/PostCommentForm.js
+++ b/web-application/client/components/posts/PostCommentForm/PostCommentForm.js
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
- *  Communities -- Non-profit, cooperative social media 
- *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *  Communities -- Non-profit, cooperative social media
+ *  Copyright (C) 2022 - 2024 Daniel Bingham
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published
@@ -49,8 +49,8 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
 
     const currentUser = useSelector((state) => state.authentication.currentUser)
 
-    const comment = useSelector((state) => commentId && commentId in state.PostComment.dictionary ? state.PostComment.dictionary[commentId] : null) 
-    
+    const comment = useSelector((state) => commentId && commentId in state.PostComment.dictionary ? state.PostComment.dictionary[commentId] : null)
+
     const dispatch = useDispatch()
 
     const getDraftKey = function() {
@@ -67,7 +67,7 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
         }
 
         if ( isLocalStorageAvailable() ) {
-            try { 
+            try {
                 localStorage.setItem(`commentDraft.${postId}`, JSON.stringify(draft))
             } catch (error) {
                 logger.error(error)
@@ -98,7 +98,7 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
      */
     const cancel = function() {
         if ( isLocalStorageAvailable() ) {
-            try { 
+            try {
                 localStorage.removeItem(getDraftKey())
             } catch (error) {
                 logger.error(error)
@@ -122,13 +122,13 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
         // For edits, check to see if they've actually made any changes.  If
         // they have, then the form is dirty.
         if ( commentId && ( content !== comment?.content ) ) {
-            return true 
-        } 
+            return true
+        }
 
         // For new comment drafts, if there's any content, then the form is dirty.
         else if ( ! commentId && content.length > 0 ) {
             return true
-        } 
+        }
 
         return false
     }
@@ -141,7 +141,7 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
         // If the form is dirty, then we want to confirm discarding the draft.
         if ( isDirty() ) {
             setAreYouSure(true)
-        } 
+        }
         else {
             cancel()
         }
@@ -165,7 +165,7 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
 
         let existingDraft = null
         if ( isLocalStorageAvailable() ) {
-            try { 
+            try {
                 existingDraft = JSON.parse(localStorage.getItem(getDraftKey()))
             } catch (error) {
                 logger.error(error)
@@ -177,7 +177,7 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
             setShowForm(true)
         } else if ( commentId && comment ) {
             if ( isLocalStorageAvailable() ) {
-                try { 
+                try {
                     localStorage.setItem(getDraftKey(), JSON.stringify(draft))
                 } catch (error) {
                     logger.error(error)
@@ -191,7 +191,7 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
     useEffect(function() {
         if ( ! postRequest && ! patchRequest && (showForm || commentId )) {
             if ( isLocalStorageAvailable() ) {
-                try { 
+                try {
                     localStorage.setItem(getDraftKey(), JSON.stringify({ content: content }))
                 } catch (error) {
                     logger.error(error)
@@ -203,7 +203,7 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
     useEffect(function() {
         if ( (postRequest && postRequest.state == 'fulfilled') || (patchRequest && patchRequest.state == 'fulfilled')) {
             if ( isLocalStorageAvailable() ) {
-                try { 
+                try {
                     localStorage.removeItem(getDraftKey())
                 } catch (error) {
                     logger.error(error)
@@ -253,11 +253,11 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
                     <Button onClick={() => handleCancel()}>Cancel</Button>
                     <Button type="primary" onClick={() => submit()}>{ commentId ? 'Save Edit' : 'Comment' }</Button>
                 </div> }
-                <AreYouSure 
-                    isVisible={areYouSure} 
+                <AreYouSure
+                    isVisible={areYouSure}
                     cancelLabel="Keep Editing"
                     executeLabel={ commentId ? "Discard Edits" : "Discard Comment" }
-                    execute={cancel} 
+                    execute={cancel}
                     cancel={() => setAreYouSure(false)}
                 >
                     <p>Are you sure you want to discard your { commentId ? "edits" : "comment" }?</p>

--- a/web-application/client/components/posts/PostCommentForm/PostCommentForm.js
+++ b/web-application/client/components/posts/PostCommentForm/PostCommentForm.js
@@ -22,6 +22,7 @@ import { useSelector, useDispatch } from 'react-redux'
 
 import logger from '/logger'
 
+import { isLocalStorageAvailable } from '/lib/localStorage'
 import { useRequest } from '/lib/hooks/useRequest'
 
 import { postPostComments, patchPostComment, finishPostCommentEdit } from '/state/PostComment'
@@ -65,7 +66,14 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
             content: ''
         }
 
-        localStorage.setItem(`commentDraft.${postId}`, JSON.stringify(draft))
+        if ( isLocalStorageAvailable() ) {
+            try { 
+                localStorage.setItem(`commentDraft.${postId}`, JSON.stringify(draft))
+            } catch (error) {
+                logger.error(error)
+            }
+        }
+
         setShowForm(true)
         setShowComments(true)
     }
@@ -89,7 +97,13 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
      * Cancel the comment and wipe out any drafts.
      */
     const cancel = function() {
-        localStorage.removeItem(getDraftKey())
+        if ( isLocalStorageAvailable() ) {
+            try { 
+                localStorage.removeItem(getDraftKey())
+            } catch (error) {
+                logger.error(error)
+            }
+        }
 
         setAreYouSure(false)
         setContent('')
@@ -149,12 +163,26 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
             content: comment ? comment.content : ''
         }
 
-        const existingDraft = JSON.parse(localStorage.getItem(getDraftKey()))
+        let existingDraft = null
+        if ( isLocalStorageAvailable() ) {
+            try { 
+                existingDraft = JSON.parse(localStorage.getItem(getDraftKey()))
+            } catch (error) {
+                logger.error(error)
+            }
+        }
+
         if ( existingDraft ) {
             draft = existingDraft
             setShowForm(true)
         } else if ( commentId && comment ) {
-            localStorage.setItem(getDraftKey(), JSON.stringify(draft))
+            if ( isLocalStorageAvailable() ) {
+                try { 
+                    localStorage.setItem(getDraftKey(), JSON.stringify(draft))
+                } catch (error) {
+                    logger.error(error)
+                }
+            }
         }
 
         setContent(draft.content)
@@ -162,13 +190,25 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
 
     useEffect(function() {
         if ( ! postRequest && ! patchRequest && (showForm || commentId )) {
-            localStorage.setItem(getDraftKey(), JSON.stringify({ content: content }))
+            if ( isLocalStorageAvailable() ) {
+                try { 
+                    localStorage.setItem(getDraftKey(), JSON.stringify({ content: content }))
+                } catch (error) {
+                    logger.error(error)
+                }
+            }
         }
     }, [ commentId, content, postRequest, patchRequest ])
 
     useEffect(function() {
         if ( (postRequest && postRequest.state == 'fulfilled') || (patchRequest && patchRequest.state == 'fulfilled')) {
-            localStorage.removeItem(getDraftKey())
+            if ( isLocalStorageAvailable() ) {
+                try { 
+                    localStorage.removeItem(getDraftKey())
+                } catch (error) {
+                    logger.error(error)
+                }
+            }
 
             setContent('')
             setError('')
@@ -192,7 +232,6 @@ const PostCommentForm = function({ postId, groupId, commentId, setShowComments }
     }
 
     const inProgress = (patchRequest && patchRequest.state == 'pending') || (postRequest && postRequest.state == 'pending')
-    const draft = localStorage.getItem(getDraftKey())
 
     if ( ! commentId && ! showForm ) {
         return (

--- a/web-application/client/lib/hooks/useLocalStorage.js
+++ b/web-application/client/lib/hooks/useLocalStorage.js
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
- *  Communities -- Non-profit, cooperative social media 
- *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *  Communities -- Non-profit, cooperative social media
+ *  Copyright (C) 2022 - 2024 Daniel Bingham
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published
@@ -24,19 +24,18 @@ import logger from '/logger'
 import { isLocalStorageAvailable } from '/lib/localStorage'
 
 
-
-
 const getLocalStorage = function(key, defaultValue) {
     if ( ! isLocalStorageAvailable() ) {
         return defaultValue
     }
 
-    try { 
+    try {
         const text = localStorage.getItem(key)
         const value = JSON.parse(text)
         return value || defaultValue
     } catch (error) {
         logger.error(error)
+        return defaultValue
     }
 }
 
@@ -46,7 +45,7 @@ export const useLocalStorage = function(key, defaultValue) {
     const setValue = (value) => {
         setInternalValue(value)
 
-        try { 
+        try {
             if ( isLocalStorageAvailable() ) {
                 if ( value === undefined || value === null || value === '' ) {
                     localStorage.removeItem(key)

--- a/web-application/client/lib/hooks/useLocalStorage.js
+++ b/web-application/client/lib/hooks/useLocalStorage.js
@@ -1,22 +1,61 @@
-import { useState, useEffect } from 'react'
+/******************************************************************************
+ *
+ *  Communities -- Non-profit, cooperative social media 
+ *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+import { useState } from 'react'
+
+import logger from '/logger'
+
+import { isLocalStorageAvailable } from '/lib/localStorage'
+
+
 
 
 const getLocalStorage = function(key, defaultValue) {
-    const text = localStorage.getItem(key)
-    const value = JSON.parse(text)
-    return value || defaultValue
+    if ( ! isLocalStorageAvailable() ) {
+        return defaultValue
+    }
+
+    try { 
+        const text = localStorage.getItem(key)
+        const value = JSON.parse(text)
+        return value || defaultValue
+    } catch (error) {
+        logger.error(error)
+    }
 }
 
 export const useLocalStorage = function(key, defaultValue) {
     const [ internalValue, setInternalValue] = useState(() => getLocalStorage(key, defaultValue))
 
     const setValue = (value) => {
-        if ( value === null || value === '' ) {
-            setInternalValue(value)
-            localStorage.removeItem(key)
-        } else {
-            setInternalValue(value)
-            localStorage.setItem(key, JSON.stringify(value))
+        setInternalValue(value)
+
+        try { 
+            if ( isLocalStorageAvailable() ) {
+                if ( value === undefined || value === null || value === '' ) {
+                    localStorage.removeItem(key)
+                } else {
+                    localStorage.setItem(key, JSON.stringify(value))
+                }
+            }
+        } catch (error) {
+            logger.error(error)
         }
     }
 

--- a/web-application/client/lib/hooks/usePostDraft.js
+++ b/web-application/client/lib/hooks/usePostDraft.js
@@ -1,3 +1,22 @@
+/******************************************************************************
+ *
+ *  Communities -- Non-profit, cooperative social media 
+ *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
 import { useSelector, useDispatch } from 'react-redux'
 
 import * as uuid from 'uuid'
@@ -5,6 +24,8 @@ import * as uuid from 'uuid'
 import logger from '/logger'
 
 import { setDraft as setPostDraft, clearDraft as clearPostDraft } from '/state/Post'
+
+import { isLocalStorageAvailable } from '/lib/localStorage'
 
 import { useGroup } from '/lib/hooks/Group'
 import { usePost } from '/lib/hooks/Post'
@@ -153,7 +174,14 @@ export const usePostDraft = function(id, groupId, sharedPostId) {
 
     // Here we want to correct the draft, because we may need to migrate drafts
     // in local storage due to code updates.
-    let savedDraft = JSON.parse(localStorage.getItem(`post.draft[${postKey}]`))
+    let savedDraft = {}
+    if ( isLocalStorageAvailable() ) {
+        try {
+            savedDraft = JSON.parse(localStorage.getItem(`post.draft[${postKey}]`))
+        } catch (error) {
+            logger.error(error)
+        }
+    }
     const draft = validateAndCorrectDraft(
         useSelector((state) => postKey in state.Post.drafts ? state.Post.drafts[postKey] : savedDraft), post, group, sharedPostId
     )
@@ -166,10 +194,22 @@ export const usePostDraft = function(id, groupId, sharedPostId) {
             // throwing an error here.
             const correctedDraft = validateAndCorrectDraft(newDraft, post, group, sharedPostId) 
             dispatch(setPostDraft({ key: postKey, draft: correctedDraft}))
-            localStorage.setItem(`post.draft[${postKey}]`, JSON.stringify(correctedDraft))
+            if ( isLocalStorageAvailable() ) {
+                try {
+                    localStorage.setItem(`post.draft[${postKey}]`, JSON.stringify(correctedDraft))
+                } catch (error) {
+                    logger.error(error)
+                }
+            }
         } else {
             dispatch(clearPostDraft({ key: postKey }))
-            localStorage.removeItem(`post.draft[${postKey}]`)
+            if ( isLocalStorageAvailable() ) {
+                try {
+                    localStorage.removeItem(`post.draft[${postKey}]`)
+                } catch (error) {
+                    logger.error(error)
+                }
+            }
         }
     }
 

--- a/web-application/client/lib/hooks/usePostDraft.js
+++ b/web-application/client/lib/hooks/usePostDraft.js
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
- *  Communities -- Non-profit, cooperative social media 
- *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *  Communities -- Non-profit, cooperative social media
+ *  Copyright (C) 2022 - 2024 Daniel Bingham
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published
@@ -49,7 +49,7 @@ const validateAndCorrectDraft = function(draft, post, group, sharedPostId) {
             defaultVisibility = 'public'
         }
     }
-    
+
     const correctedDraft = {
         content: post ? post.content : '',
         linkPreviewId: post ? post.linkPreviewId : null,
@@ -57,16 +57,16 @@ const validateAndCorrectDraft = function(draft, post, group, sharedPostId) {
         ignoredLinks: [],
         sharedPostId: post ? post.sharedPostId : sharedPostId,
         visibility: post ? post.visibility : defaultVisibility,
-        type: post ? post.type : defaultType 
+        type: post ? post.type : defaultType
     }
 
     if ( draft === undefined || draft === null ) {
-        return correctedDraft 
+        return correctedDraft
     }
 
-    if ( has(draft, 'content') 
+    if ( has(draft, 'content')
         && draft.content !== null
-        && typeof draft.content === 'string' 
+        && typeof draft.content === 'string'
     ) {
         correctedDraft.content = draft.content
     }
@@ -85,11 +85,11 @@ const validateAndCorrectDraft = function(draft, post, group, sharedPostId) {
         && Array.isArray(draft.files)
         && correctedDraft.sharedPostId === null
     ) {
-        correctedDraft.files = draft.files 
-    } 
+        correctedDraft.files = draft.files
+    }
 
-    if ( has(draft, 'fileId') 
-        && draft.fileId !== null 
+    if ( has(draft, 'fileId')
+        && draft.fileId !== null
         && uuid.validate(draft.fileId)
         && correctedDraft.sharedPostId === null
     ) {
@@ -97,13 +97,13 @@ const validateAndCorrectDraft = function(draft, post, group, sharedPostId) {
             correctedDraft.files.push(draft.fileId)
             delete draft.fileId
         }
-    } 
+    }
 
     if( has(draft, 'linkPreviewId')
         && draft.linkPreviewId !== null
         && uuid.validate(draft.linkPreviewId)
         && correctedDraft.sharedPostId === null
-        && correctedDraft.files.length <= 0 
+        && correctedDraft.files.length <= 0
     ) {
         correctedDraft.linkPreviewId = draft.linkPreviewId
     } else if ( has(draft, 'linkPreviewId') && draft.linkPreviewId === null ) {
@@ -141,7 +141,7 @@ const validateAndCorrectDraft = function(draft, post, group, sharedPostId) {
         }  else if ( draft.type === 'feed' || draft.type === 'announcement' || draft.type === 'info' )  {
             correctedDraft.type = draft.type
         }
-    } 
+    }
 
     return correctedDraft
 }
@@ -163,7 +163,7 @@ const getDraftKey = function(id, groupId, sharedPostId) {
         key = key + `sharedPostId:${sharedPostId}`
     }
 
-    return key 
+    return key
 }
 
 export const usePostDraft = function(id, groupId, sharedPostId) {
@@ -192,7 +192,7 @@ export const usePostDraft = function(id, groupId, sharedPostId) {
         if ( newDraft !== null ) {
             // TechDebt TODO really we should be validating the draft and
             // throwing an error here.
-            const correctedDraft = validateAndCorrectDraft(newDraft, post, group, sharedPostId) 
+            const correctedDraft = validateAndCorrectDraft(newDraft, post, group, sharedPostId)
             dispatch(setPostDraft({ key: postKey, draft: correctedDraft}))
             if ( isLocalStorageAvailable() ) {
                 try {

--- a/web-application/client/lib/localStorage/index.js
+++ b/web-application/client/lib/localStorage/index.js
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
- *  Communities -- Non-profit, cooperative social media 
- *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *  Communities -- Non-profit, cooperative social media
+ *  Copyright (C) 2022 - 2024 Daniel Bingham
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published
@@ -17,6 +17,8 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  ******************************************************************************/
+import logger from '/logger'
+
 let hasLocalStorage = null
 
 /** Can we use local storage? **/
@@ -27,17 +29,20 @@ export const isLocalStorageAvailable = function() {
     }
 
     try {
-        if ( ! ('localStorage' in window) ) {
-            return false
+        if ( ! ('localStorage' in window) || window.localStorage === null ) {
+            logger.warn(`'localStorage' not available.`)
+            hasLocalStorage = false
+            return hasLocalStorage
         }
 
         localStorage.setItem('__storage_test__', 'pending')
         localStorage.removeItem('__storage_test__')
 
         hasLocalStorage = true
-        return hasLocalStorage 
+        return hasLocalStorage
     } catch (error) {
+        logger.warn(`'localStorage' not availabile: `, error)
         hasLocalStorage = false
-        return hasLocalStorage 
+        return hasLocalStorage
     }
 }

--- a/web-application/client/lib/localStorage/index.js
+++ b/web-application/client/lib/localStorage/index.js
@@ -17,10 +17,15 @@
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  ******************************************************************************/
-import logger from '/logger'
+let hasLocalStorage = null
 
 /** Can we use local storage? **/
 export const isLocalStorageAvailable = function() {
+    // If we've already checked localStorage for this load.
+    if ( hasLocalStorage === true || hasLocalStorage === false) {
+        return hasLocalStorage
+    }
+
     try {
         if ( ! ('localStorage' in window) ) {
             return false
@@ -28,9 +33,11 @@ export const isLocalStorageAvailable = function() {
 
         localStorage.setItem('__storage_test__', 'pending')
         localStorage.removeItem('__storage_test__')
-        return true
+
+        hasLocalStorage = true
+        return hasLocalStorage 
     } catch (error) {
-        logger.warn(`LocalStorage is not available: `, error)
-        return false
+        hasLocalStorage = false
+        return hasLocalStorage 
     }
 }

--- a/web-application/client/migrations/StorageMigrations.js
+++ b/web-application/client/migrations/StorageMigrations.js
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
- *  Communities -- Non-profit, cooperative social media 
- *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *  Communities -- Non-profit, cooperative social media
+ *  Copyright (C) 2022 - 2024 Daniel Bingham
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published
@@ -24,7 +24,7 @@ import { isLocalStorageAvailable } from '/lib/localStorage'
 const currentVersion = 1
 
 const migrateVersion0to1= function() {
-    try { 
+    try {
         logger.info(`Migrating localStorage from version 0 to version 1...`)
         // We're not going to both trying to migrate from version zero.  Just wipe
         // it out and give us a clean slate.  The only thing in there should be
@@ -41,13 +41,13 @@ const migrations = [
 ]
 
 export default function migrateLocalStorage() {
-    try { 
+    try {
         if ( ! isLocalStorageAvailable() ) {
             return
         }
 
-        const storageVersion = parseInt(localStorage.getItem('version'))
-        if ( storageVersion === NaN ) {
+        let storageVersion = parseInt(localStorage.getItem('version'))
+        if ( Number.isNaN(storageVersion) ) {
             storageVersion = 0
         }
 

--- a/web-application/client/migrations/StorageMigrations.js
+++ b/web-application/client/migrations/StorageMigrations.js
@@ -19,14 +19,20 @@
  ******************************************************************************/
 import logger from '/logger'
 
+import { isLocalStorageAvailable } from '/lib/localStorage'
+
 const currentVersion = 1
 
 const migrateVersion0to1= function() {
-    logger.info(`Migrating localStorage from version 0 to version 1...`)
-    // We're not going to both trying to migrate from version zero.  Just wipe
-    // it out and give us a clean slate.  The only thing in there should be
-    // drafts.
-    localStorage.clear()
+    try { 
+        logger.info(`Migrating localStorage from version 0 to version 1...`)
+        // We're not going to both trying to migrate from version zero.  Just wipe
+        // it out and give us a clean slate.  The only thing in there should be
+        // drafts.
+        localStorage.clear()
+    } catch (error) {
+        logger.error(`Failed to migrate from version 0 to 1: `, error)
+    }
 }
 
 // Order matters!
@@ -35,23 +41,31 @@ const migrations = [
 ]
 
 export default function migrateLocalStorage() {
-    const storageVersion = parseInt(localStorage.getItem('version'))
-    if ( storageVersion === NaN ) {
-        storageVersion = 0
-    }
-
-    logger.info(`Current localStorage version: `, storageVersion)
-
-    // Start with the storage version and run each migration up to the current
-    // version in order.  This is why order matters in the migrations array.
-    if ( storageVersion !== currentVersion) {
-        for(let index = storageVersion; index < migrations.length; index++) {
-            const migration = migrations[index]
-            migration()
+    try { 
+        if ( ! isLocalStorageAvailable() ) {
+            return
         }
-        logger.info(`Migrated localStorage to version: `, currentVersion)
-        localStorage.setItem('version', currentVersion)
-    } else {
-        logger.info(`localStorage up to date with version: `, currentVersion)
+
+        const storageVersion = parseInt(localStorage.getItem('version'))
+        if ( storageVersion === NaN ) {
+            storageVersion = 0
+        }
+
+        logger.info(`Current localStorage version: `, storageVersion)
+
+        // Start with the storage version and run each migration up to the current
+        // version in order.  This is why order matters in the migrations array.
+        if ( storageVersion !== currentVersion) {
+            for(let index = storageVersion; index < migrations.length; index++) {
+                const migration = migrations[index]
+                migration()
+            }
+            logger.info(`Migrated localStorage to version: `, currentVersion)
+            localStorage.setItem('version', currentVersion)
+        } else {
+            logger.info(`localStorage up to date with version: `, currentVersion)
+        }
+    } catch (error) {
+        logger.error(`Failed to migrate localstorage: `, error)
     }
 }

--- a/web-application/client/pages/authentication/AgeGate.js
+++ b/web-application/client/pages/authentication/AgeGate.js
@@ -25,6 +25,7 @@ import logger from '/logger'
 import { deleteUser } from '/state/User'
 import { reset } from '/state/system'
 
+import { isLocalStorageAvailable } from '/lib/localStorage'
 import { useRequest } from '/lib/hooks/useRequest'
 
 import CommunitiesLogo from '/components/header/CommunitiesLogo'
@@ -42,9 +43,16 @@ const AgeGate = function() {
     useEffect(function() {
         if ( request && request.state == 'fulfilled') {
 
-            // Clear local storage so their drafts don't carry over to another
-            // login session.
-            localStorage.clear()
+
+            if ( isLocalStorageAvailable() ) {
+                try { 
+                    // Clear local storage so their drafts don't carry over to another
+                    // login session.
+                    localStorage.clear()
+                } catch (error) {
+                    logger.error(error)
+                }
+            }
 
             dispatch(reset())
 

--- a/web-application/client/pages/authentication/AgeGate.js
+++ b/web-application/client/pages/authentication/AgeGate.js
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
- *  Communities -- Non-profit, cooperative social media 
- *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *  Communities -- Non-profit, cooperative social media
+ *  Copyright (C) 2022 - 2024 Daniel Bingham
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published
@@ -45,7 +45,7 @@ const AgeGate = function() {
 
 
             if ( isLocalStorageAvailable() ) {
-                try { 
+                try {
                     // Clear local storage so their drafts don't carry over to another
                     // login session.
                     localStorage.clear()

--- a/web-application/client/pages/users/views/UserAccountDangerZoneView.js
+++ b/web-application/client/pages/users/views/UserAccountDangerZoneView.js
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
- *  Communities -- Non-profit, cooperative social media 
- *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *  Communities -- Non-profit, cooperative social media
+ *  Copyright (C) 2022 - 2024 Daniel Bingham
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published
@@ -54,7 +54,7 @@ const UserAccountDangerZoneView = function() {
         if ( request && request.state == 'fulfilled') {
 
             if ( isLocalStorageAvailable() ) {
-                try { 
+                try {
                     // Clear local storage so their drafts don't carry over to another
                     // login session.
                     localStorage.clear()
@@ -83,7 +83,7 @@ const UserAccountDangerZoneView = function() {
                     <div className="danger-zone-view__button-wrapper">
                         <Button type="warn" onClick={(e) => setAreYouSure(true)}>Delete My Account</Button>
                     </div>
-                    <AreYouSure isVisible={areYouSure} execute={deleteCurrentUser} cancel={() => setAreYouSure(false)} > 
+                    <AreYouSure isVisible={areYouSure} execute={deleteCurrentUser} cancel={() => setAreYouSure(false)} >
                         <p>Are you sure you want to delete your account?</p>
                     </AreYouSure>
                 </div>

--- a/web-application/client/pages/users/views/UserAccountDangerZoneView.js
+++ b/web-application/client/pages/users/views/UserAccountDangerZoneView.js
@@ -1,5 +1,28 @@
-import React, { useState, useEffect } from 'react'
+/******************************************************************************
+ *
+ *  Communities -- Non-profit, cooperative social media 
+ *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+import { useState, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
+
+import logger from '/logger'
+
+import { isLocalStorageAvailable } from '/lib/localStorage'
 
 import { useRequest } from '/lib/hooks/useRequest'
 import { deleteUser } from '/state/User'
@@ -30,9 +53,15 @@ const UserAccountDangerZoneView = function() {
     useEffect(function() {
         if ( request && request.state == 'fulfilled') {
 
-            // Clear local storage so their drafts don't carry over to another
-            // login session.
-            localStorage.clear()
+            if ( isLocalStorageAvailable() ) {
+                try { 
+                    // Clear local storage so their drafts don't carry over to another
+                    // login session.
+                    localStorage.clear()
+                } catch (error) {
+                    logger.error(error)
+                }
+            }
 
             dispatch(reset())
 

--- a/web-application/client/pages/users/views/UserAccountSettingsView.js
+++ b/web-application/client/pages/users/views/UserAccountSettingsView.js
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
- *  Communities -- Non-profit, cooperative social media 
- *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *  Communities -- Non-profit, cooperative social media
+ *  Copyright (C) 2022 - 2024 Daniel Bingham
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published
@@ -55,7 +55,7 @@ const UserAccountSettingsView = function() {
         if ( request && request.state == 'fulfilled') {
 
             if ( isLocalStorageAvailable() ) {
-                try { 
+                try {
                     // Clear local storage so their drafts don't carry over to another
                     // login session.
                     localStorage.clear()
@@ -85,7 +85,7 @@ const UserAccountSettingsView = function() {
                     <div className="user-settings__button-wrapper">
                         <Button type="warn" onClick={(e) => setAreYouSure(true)}>Delete My Account</Button>
                     </div>
-                    <AreYouSure isVisible={areYouSure} execute={deleteCurrentUser} cancel={() => setAreYouSure(false)} > 
+                    <AreYouSure isVisible={areYouSure} execute={deleteCurrentUser} cancel={() => setAreYouSure(false)} >
                         <p>Are you sure you want to delete your account?</p>
                     </AreYouSure>
                 </div>

--- a/web-application/client/pages/users/views/UserAccountSettingsView.js
+++ b/web-application/client/pages/users/views/UserAccountSettingsView.js
@@ -1,6 +1,28 @@
-import React, { useState, useEffect } from 'react'
+/******************************************************************************
+ *
+ *  Communities -- Non-profit, cooperative social media 
+ *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+import { useState, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 
+import logger from '/logger'
+
+import { isLocalStorageAvailable } from '/lib/localStorage'
 import { useRequest } from '/lib/hooks/useRequest'
 import { deleteUser } from '/state/User'
 import { reset } from '/state/system'
@@ -32,9 +54,15 @@ const UserAccountSettingsView = function() {
     useEffect(function() {
         if ( request && request.state == 'fulfilled') {
 
-            // Clear local storage so their drafts don't carry over to another
-            // login session.
-            localStorage.clear()
+            if ( isLocalStorageAvailable() ) {
+                try { 
+                    // Clear local storage so their drafts don't carry over to another
+                    // login session.
+                    localStorage.clear()
+                } catch (error) {
+                    logger.error(error)
+                }
+            }
 
             dispatch(reset())
 

--- a/web-application/client/state/authentication.js
+++ b/web-application/client/state/authentication.js
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
- *  Communities -- Non-profit, cooperative social media 
- *  Copyright (C) 2022 - 2024 Daniel Bingham 
+ *  Communities -- Non-profit, cooperative social media
+ *  Copyright (C) 2022 - 2024 Daniel Bingham
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published
@@ -22,6 +22,8 @@ import { createSlice } from '@reduxjs/toolkit'
 import { Capacitor } from '@capacitor/core'
 import { SecureStoragePlugin } from 'capacitor-secure-storage-plugin'
 
+import logger from '/logger'
+
 import { isLocalStorageAvailable } from '/lib/localStorage'
 import { makeRequest } from '/state/lib/makeRequest'
 
@@ -35,7 +37,7 @@ export const authenticationSlice = createSlice({
         /**
          * A `user` object representing the currentUser.
          *
-         * @type {object} 
+         * @type {object}
          */
         currentUser: null,
 
@@ -97,7 +99,7 @@ export const setSession = function(session) {
 
 /**
  * Call getAuthentication and cleanup the created request as soon as it
- * returns.  
+ * returns.
  *
  * Use this to refresh authentication in contexts where we don't need to track
  * the request.
@@ -226,9 +228,13 @@ export const deleteAuthentication = function() {
                 if ( Capacitor.getPlatform() === 'ios' || Capacitor.getPlatform() === 'android' ) {
                     SecureStoragePlugin.clear().then(function() {
                         if ( isLocalStorageAvailable() ) {
-                            // Clear local storage so their drafts don't carry over to another
-                            // login session.
-                            localStorage.clear()
+                            try {
+                                // Clear local storage so their drafts don't carry over to another
+                                // login session.
+                                localStorage.clear()
+                            } catch (error) {
+                                logger.error(error)
+                            }
                         }
 
                         dispatch(reset())
@@ -240,9 +246,13 @@ export const deleteAuthentication = function() {
                     })
                 } else {
                     if ( isLocalStorageAvailable() ) {
-                        // Clear local storage so their drafts don't carry over to another
-                        // login session.
-                        localStorage.clear()
+                        try {
+                            // Clear local storage so their drafts don't carry over to another
+                            // login session.
+                            localStorage.clear()
+                        } catch (error) {
+                            logger.error(error)
+                        }
                     }
 
                     dispatch(reset())


### PR DESCRIPTION
`localStorage` can be disabled in some browsers and contexts and it causes the bug screen.  It's one of the few remaining critical errors. We need to check for local storage availability before using it.  In cases where it's not available, we just won't store drafts.

Resolves #525